### PR TITLE
Fix CI: add --force to cargo install wasm-pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,5 @@ jobs:
 
       - name: Build WASM
         run: |
-          cargo install wasm-pack --version 0.13.1 --locked
+          cargo install wasm-pack --version 0.13.1 --locked --force
           wasm-pack build --target web --release


### PR DESCRIPTION
## Summary

- Add `--force` flag to `cargo install wasm-pack` to fix CI failure

## Problem

CI fails with `error: binary 'wasm-pack' already exists in destination` because `~/.cargo/bin` is cached and the binary already exists on subsequent runs.

## Test plan

- [ ] CI passes on this PR

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)