### PR TITLE
Add TypeScript wrapper with lazy WASM initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /pkg
+/dist
+/node_modules
 *.wasm.gz

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ cd gpx2geojson-wasm
 
 ## テスト
 
+### Rust テスト
+
 ```bash
 # 全テスト実行（ユニット + インテグレーション + スナップショット）
 cargo test
@@ -38,6 +40,26 @@ cargo test --test snapshot_test
 # スナップショットの期待ファイルを生成/更新
 UPDATE_SNAPSHOTS=1 cargo test --test snapshot_test
 ```
+
+### ブラウザテスト
+
+TypeScript ラッパーと WASM の動作をブラウザで確認できます。
+
+```bash
+# ビルド（WASM + TypeScript）
+npm install
+npm run build
+
+# ローカルサーバー起動
+npm run serve
+
+# ブラウザで http://localhost:3000/test.html を開く
+```
+
+`test.html` は自動的にテストを実行し、以下を検証します：
+- WASM の自動初期化
+- Waypoint と Track の変換
+- GeoJSON の構造と座標値
 
 ## WASM ビルド
 

--- a/js/index.ts
+++ b/js/index.ts
@@ -1,0 +1,34 @@
+import type { FeatureCollection } from "geojson";
+import type { ConvertOptions } from "./types.js";
+export type { ConvertOptions, GpxElementType } from "./types.js";
+export type { FeatureCollection } from "geojson";
+
+import initWasm, {
+  gpxToGeoJson as rawGpxToGeoJson,
+  gpxToGeoJsonString as rawGpxToGeoJsonString,
+} from "../pkg/gpx2geojson_wasm.js";
+
+let initPromise: Promise<void> | null = null;
+
+function ensureInit(): Promise<void> {
+  if (!initPromise) {
+    initPromise = initWasm().then(() => {});
+  }
+  return initPromise;
+}
+
+export async function gpxToGeoJson(
+  gpxString: string,
+  options?: ConvertOptions
+): Promise<FeatureCollection> {
+  await ensureInit();
+  return rawGpxToGeoJson(gpxString, options ?? undefined) as FeatureCollection;
+}
+
+export async function gpxToGeoJsonString(
+  gpxString: string,
+  options?: ConvertOptions
+): Promise<string> {
+  await ensureInit();
+  return rawGpxToGeoJsonString(gpxString, options ?? undefined);
+}

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "../dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.ts"]
+}

--- a/js/types.ts
+++ b/js/types.ts
@@ -1,0 +1,13 @@
+import type { FeatureCollection } from "geojson";
+
+export type { FeatureCollection };
+
+export type GpxElementType = "waypoint" | "route" | "track";
+
+export interface ConvertOptions {
+  includeElevation?: boolean;
+  includeTime?: boolean;
+  includeMetadata?: boolean;
+  types?: GpxElementType[];
+  joinTrackSegments?: boolean;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,38 @@
+{
+  "name": "gpx2geojson-wasm",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gpx2geojson-wasm",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/geojson": "^7946.0.14",
+        "typescript": "^5.7"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "gpx2geojson-wasm",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist/",
+    "pkg/gpx2geojson_wasm_bg.wasm",
+    "pkg/gpx2geojson_wasm.js",
+    "pkg/gpx2geojson_wasm.d.ts"
+  ],
+  "scripts": {
+    "build:wasm": "wasm-pack build --target web --release",
+    "build:js": "tsc -p js/tsconfig.json",
+    "build": "npm run build:wasm && npm run build:js"
+  },
+  "devDependencies": {
+    "@types/geojson": "^7946.0.14",
+    "typescript": "^5.7"
+  },
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "build:wasm": "wasm-pack build --target web --release",
     "build:js": "tsc -p js/tsconfig.json",
-    "build": "npm run build:wasm && npm run build:js"
+    "build": "npm run build:wasm && npm run build:js",
+    "serve": "npx serve ."
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.14",

--- a/test.html
+++ b/test.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>gpx2geojson-wasm test</title>
+  <style>
+    body { font-family: monospace; margin: 2rem; }
+    pre { background: #f4f4f4; padding: 1rem; overflow: auto; }
+    .error { color: red; }
+    .ok { color: green; }
+  </style>
+</head>
+<body>
+  <h1>gpx2geojson-wasm browser test</h1>
+  <p id="status">Loading...</p>
+  <pre id="output"></pre>
+  <script type="module">
+    import { gpxToGeoJson } from './dist/index.js';
+
+    const gpx = `<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test"
+     xmlns="http://www.topografix.com/GPX/1/1">
+  <wpt lat="35.6812" lon="139.7671">
+    <name>Tokyo Station</name>
+    <ele>3.0</ele>
+  </wpt>
+  <trk>
+    <name>Imperial Palace Run</name>
+    <trkseg>
+      <trkpt lat="35.6852" lon="139.7528"><ele>10</ele></trkpt>
+      <trkpt lat="35.6870" lon="139.7560"><ele>12</ele></trkpt>
+      <trkpt lat="35.6838" lon="139.7590"><ele>11</ele></trkpt>
+    </trkseg>
+  </trk>
+</gpx>`;
+
+    const status = document.getElementById('status');
+    const output = document.getElementById('output');
+
+    try {
+      const geojson = await gpxToGeoJson(gpx);
+      status.textContent = `OK: ${geojson.features.length} feature(s)`;
+      status.className = 'ok';
+      output.textContent = JSON.stringify(geojson, null, 2);
+      console.log('gpxToGeoJson result:', geojson);
+    } catch (e) {
+      status.textContent = 'Error: ' + e;
+      status.className = 'error';
+      output.textContent = String(e.stack || e);
+      console.error(e);
+    }
+  </script>
+</body>
+</html>

--- a/test.html
+++ b/test.html
@@ -49,7 +49,7 @@
   </details>
 
   <script type="module">
-    import { gpxToGeoJson } from './dist/index.js';
+    import { gpxToGeoJson, gpxToGeoJsonString } from './dist/index.js';
 
     const gpx = `<?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.1" creator="test"
@@ -72,40 +72,51 @@
     const output = document.getElementById('output');
     document.getElementById('input-gpx').textContent = gpx;
 
-    function setCheck(id, pass) {
+    function setCheck(id, pass, detail) {
       const el = document.getElementById(id);
       el.classList.add(pass ? 'pass' : 'fail');
+      if (detail) el.textContent += ` — ${detail}`;
     }
 
     try {
-      const geojson = await gpxToGeoJson(gpx);
+      // gpxToGeoJsonString で JSON 文字列を取得し、パースして検証
+      const jsonStr = await gpxToGeoJsonString(gpx);
+      const geojson = JSON.parse(jsonStr);
       setCheck('check-init', true);
 
       output.textContent = JSON.stringify(geojson, null, 2);
 
-      const features = geojson.features || [];
-      setCheck('check-features', features.length === 2);
+      // gpxToGeoJson (JsValue 返却) も動作確認
+      const geojsonObj = await gpxToGeoJson(gpx);
+      console.log('gpxToGeoJson (JsValue):', geojsonObj);
+      console.log('gpxToGeoJsonString (parsed):', geojson);
 
-      const wpt = features.find(f => f.geometry.type === 'Point');
+      const features = geojson.features || [];
+      const featureOk = features.length === 2;
+      setCheck('check-features', featureOk, `実際: ${features.length} 件`);
+
+      const wpt = features.find(f => f.geometry && f.geometry.type === 'Point');
       const wptOk = wpt
         && wpt.geometry.coordinates[0] === 139.7671
         && wpt.geometry.coordinates[1] === 35.6812
-        && wpt.properties.name === 'Tokyo Station';
-      setCheck('check-wpt', wptOk);
+        && wpt.properties && wpt.properties.name === 'Tokyo Station';
+      setCheck('check-wpt', !!wptOk,
+        wpt ? `coords=[${wpt.geometry.coordinates}], name="${wpt.properties?.name}"` : '見つからず');
 
-      const trk = features.find(f => f.geometry.type === 'LineString');
+      const trk = features.find(f => f.geometry && f.geometry.type === 'LineString');
       const trkOk = trk
         && trk.geometry.coordinates.length === 3
-        && trk.properties.name === 'Imperial Palace Run';
-      setCheck('check-trk', trkOk);
+        && trk.properties && trk.properties.name === 'Imperial Palace Run';
+      setCheck('check-trk', !!trkOk,
+        trk ? `coords=${trk.geometry.coordinates.length}点, name="${trk.properties?.name}"` : '見つからず');
 
-      const allPassed = features.length === 2 && wptOk && trkOk;
+      const allPassed = featureOk && wptOk && trkOk;
       status.textContent = allPassed
         ? '全テスト合格'
         : '一部テストが失敗しました（上の確認項目を参照）';
       status.className = allPassed ? 'ok' : 'error';
     } catch (e) {
-      setCheck('check-init', false);
+      setCheck('check-init', false, String(e));
       status.textContent = 'エラー: ' + e;
       status.className = 'error';
       output.textContent = String(e.stack || e);

--- a/test.html
+++ b/test.html
@@ -1,19 +1,53 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
   <meta charset="utf-8">
-  <title>gpx2geojson-wasm test</title>
+  <title>gpx2geojson-wasm 動作確認</title>
   <style>
-    body { font-family: monospace; margin: 2rem; }
-    pre { background: #f4f4f4; padding: 1rem; overflow: auto; }
-    .error { color: red; }
-    .ok { color: green; }
+    body { font-family: sans-serif; margin: 2rem; max-width: 900px; }
+    h1 { font-size: 1.4rem; }
+    pre { background: #f4f4f4; padding: 1rem; overflow: auto; border-radius: 4px; font-size: 0.85rem; }
+    .error { color: red; font-weight: bold; }
+    .ok { color: green; font-weight: bold; }
+    .pending { color: #888; }
+    .checklist { list-style: none; padding: 0; }
+    .checklist li { padding: 0.3rem 0; }
+    .checklist li::before { content: "⏳ "; }
+    .checklist li.pass::before { content: "✅ "; }
+    .checklist li.fail::before { content: "❌ "; }
+    details { margin-top: 1rem; }
+    summary { cursor: pointer; font-weight: bold; }
+    section { margin-bottom: 1.5rem; }
   </style>
 </head>
 <body>
-  <h1>gpx2geojson-wasm browser test</h1>
-  <p id="status">Loading...</p>
-  <pre id="output"></pre>
+  <h1>gpx2geojson-wasm 動作確認</h1>
+
+  <section>
+    <p>ページを開くと自動でテストが実行されます。操作は不要です。</p>
+    <p id="status" class="pending">テスト実行中...</p>
+  </section>
+
+  <section>
+    <h2>確認項目</h2>
+    <ul class="checklist">
+      <li id="check-init">WASM の初期化（自動 init）</li>
+      <li id="check-features">Feature 数が 2 件（waypoint + track）</li>
+      <li id="check-wpt">Waypoint: Point (35.6812, 139.7671), name="Tokyo Station"</li>
+      <li id="check-trk">Track: LineString (3点), name="Imperial Palace Run"</li>
+    </ul>
+  </section>
+
+  <details>
+    <summary>変換結果 (GeoJSON)</summary>
+    <pre id="output"></pre>
+  </details>
+
+  <details>
+    <summary>入力 GPX</summary>
+    <pre id="input-gpx"></pre>
+  </details>
+
   <script type="module">
     import { gpxToGeoJson } from './dist/index.js';
 
@@ -36,15 +70,43 @@
 
     const status = document.getElementById('status');
     const output = document.getElementById('output');
+    document.getElementById('input-gpx').textContent = gpx;
+
+    function setCheck(id, pass) {
+      const el = document.getElementById(id);
+      el.classList.add(pass ? 'pass' : 'fail');
+    }
 
     try {
       const geojson = await gpxToGeoJson(gpx);
-      status.textContent = `OK: ${geojson.features.length} feature(s)`;
-      status.className = 'ok';
+      setCheck('check-init', true);
+
       output.textContent = JSON.stringify(geojson, null, 2);
-      console.log('gpxToGeoJson result:', geojson);
+
+      const features = geojson.features || [];
+      setCheck('check-features', features.length === 2);
+
+      const wpt = features.find(f => f.geometry.type === 'Point');
+      const wptOk = wpt
+        && wpt.geometry.coordinates[0] === 139.7671
+        && wpt.geometry.coordinates[1] === 35.6812
+        && wpt.properties.name === 'Tokyo Station';
+      setCheck('check-wpt', wptOk);
+
+      const trk = features.find(f => f.geometry.type === 'LineString');
+      const trkOk = trk
+        && trk.geometry.coordinates.length === 3
+        && trk.properties.name === 'Imperial Palace Run';
+      setCheck('check-trk', trkOk);
+
+      const allPassed = features.length === 2 && wptOk && trkOk;
+      status.textContent = allPassed
+        ? '全テスト合格'
+        : '一部テストが失敗しました（上の確認項目を参照）';
+      status.className = allPassed ? 'ok' : 'error';
     } catch (e) {
-      status.textContent = 'Error: ' + e;
+      setCheck('check-init', false);
+      status.textContent = 'エラー: ' + e;
       status.className = 'error';
       output.textContent = String(e.stack || e);
       console.error(e);


### PR DESCRIPTION
## 概要
- `js/index.ts` に遅延WASM初期化を実装 — ユーザーは `init()` を呼ばずに `gpxToGeoJson()` を直接使用可能
- `js/types.ts` に `ConvertOptions` と `GpxElementType` の型定義を追加（Rust `options.rs` と一致）
- ルート `package.json` に ESM exports、ビルドスクリプト、`@types/geojson` による `FeatureCollection` 戻り値型を設定
- `.gitignore` に `dist/` と `node_modules/` を追加
- `test.html` にブラウザ確認用ページを追加

## 使用例
```typescript
import { gpxToGeoJson } from 'gpx2geojson-wasm';
const result = await gpxToGeoJson(gpxString); // 自動初期化、init() 不要
```

## テスト計画
- [x] `npm run build:js` でコンパイル成功
- [x] `npx tsc -p js/tsconfig.json --noEmit` で型チェック通過
- [x] `dist/` に `index.js`, `index.d.ts`, `types.js`, `types.d.ts` とdeclaration mapが生成される
- [ ] ブラウザでWASMの実行時動作を確認

## ブラウザでの確認方法

```bash
npm run build   # wasm-pack + tsc
npm run serve   # ローカルサーバー起動
# → http://localhost:3000/test.html を開く
```

`test.html` にはウェイポイント＋トラックを含むサンプルGPXが埋め込まれています。
ページ上に `OK: 2 feature(s)` と整形済みGeoJSON が表示されれば成功です。

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)